### PR TITLE
chore: 테스트 docstring 의 가변 카운트·스테이지 마커 정리

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,8 @@
 """rhwp-py CLI 서브커맨드 smoke + 통합 테스트.
 
-cli.md § 테스트 전략 — typer.testing.CliRunner 기반 smoke + 실제 sample 통합.
-파일 레벨 ``importorskip("typer")`` 로 typer 미설치 시 file 전체 skip
-(CI ``test-without-extras`` 잡의 5 skipped 카운트 중 1).
+typer.testing.CliRunner 기반 smoke + 실제 sample 통합. 파일 레벨
+``importorskip("typer")`` 로 typer 미설치 시 file 전체 skip — gated 파일
+총 카운트 검증은 CI ``test-without-extras`` 잡이 SSOT.
 """
 
 import json
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-# ^ typer / langchain extras 가드 — typer 미설치 시 file 전체 skip (1 카운트)
+# ^ typer extras 가드 — 미설치 시 file 전체 skip
 pytest.importorskip("typer")
 import rhwp  # noqa: E402
 from rhwp.cli.app import app  # noqa: E402

--- a/tests/test_ir_schema_export.py
+++ b/tests/test_ir_schema_export.py
@@ -66,7 +66,6 @@ def test_export_schema_defs_are_exactly_the_known_nodes():
         "FormulaBlock",
         "FootnoteBlock",
         "EndnoteBlock",
-        # ^ S3 신규 5
         "ListItemBlock",
         "CaptionBlock",
         "TocBlock",

--- a/tests/test_langchain_loader_ir.py
+++ b/tests/test_langchain_loader_ir.py
@@ -1,8 +1,7 @@
-"""Stage S5 — HwpLoader(mode="ir-blocks") pytest 스위트.
+"""HwpLoader(mode="ir-blocks") pytest 스위트.
 
-``test_langchain_loader.py`` 는 CLAUDE.md 규약상 exactly 29 테스트 유지 —
-IR 모드 추가 테스트는 본 파일로 분리한다. 둘 모두 ``langchain_core`` 미설치
-시 파일 레벨 importorskip 으로 auto-skip.
+``test_langchain_loader.py`` 와 분리 — 본 파일은 ir-blocks 모드 전용.
+``langchain_core`` 미설치 시 파일 레벨 importorskip 으로 auto-skip.
 """
 
 from pathlib import Path


### PR DESCRIPTION
## Summary

- `tests/test_cli.py` 의 \"5 skipped 카운트 중 1\" / \"1 카운트\" docstring·주석 제거
- `tests/test_langchain_loader_ir.py` 의 \"exactly 29 테스트 유지\" 제거 — 다른 파일 카운트가 본 파일에 박혀 invisible coupling
- `tests/test_ir_schema_export.py` 의 \"S3 신규 5\" 매직 넘버 제거

코드 동작 변화 없음 — docstring/comment only.

## Why

다른 파일·CI 잡에 의존하는 카운트가 docstring 에 박혀 있어, 카운트가 바뀔 때마다 *모든* 사본을 동기화해야 하는 안티패턴. 실제로 v0.3.0 막판 \`test_async.py\` de-gating 으로 skip count 가 5→4 로 바뀌면서 \`test_cli.py\` docstring 의 5 정정이 누락됐음.

CLAUDE.md 글로벌 원칙과도 충돌:

> Don't reference the current task, fix, or callers... since those belong in the PR description and rot as the codebase evolves.

SSOT (\`ci.yml\` test-without-extras 잡, 각 테스트 파일 자체) 만 두고 docstring 은 의도만 적도록 단일화.

## Related Issues

없음 — 코드 리뷰 중 발견.

## Test plan

- [x] \`uv run pytest tests/test_cli.py tests/test_langchain_loader_ir.py tests/test_ir_schema_export.py -v\` → 50 passed
- [x] autolint hook (\`ruff format\`/\`ruff check\`/\`pyright\`) 통과
- [ ] CI green