### PR TITLE
build: cargo test 실행 가능하도록 PyO3 extension-module feature 분리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,26 @@ jobs:
       - run: uv pip install --reinstall dist/*.whl
       - run: uv run pytest tests/ -m slow -v
 
+  # * Rust unit tests — src/ir.rs 의 #[cfg(test)] 모듈 실행
+  #   Cargo.toml 의 default features 에서 extension-module 이 빠져 있어 libpython 링크 시도 안 함.
+  #   utf16_to_cp / simple_eq_text_alt / field_type_to_str / caption_direction_to_str /
+  #   assert_position_invariant (#[should_panic]) 검증 — Python 측에서 우회 불가능한 Rust 도메인 로직.
+  cargo-test:
+    name: Cargo test (Rust unit tests)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Run cargo test (default features — extension-module disabled)
+        run: cargo test --lib
+
   # * extras 미설치 시 langchain 테스트가 importorskip 로 auto-skip 되는지 검증
   test-core-only:
     name: Test without extras (importorskip auto-skip)
@@ -227,9 +247,9 @@ jobs:
     name: All tests passed
     if: always()
     runs-on: ubuntu-latest
-    needs: [changes, build-linux-wheel, test, test-other-os, test-slow, test-core-only]
+    needs: [changes, build-linux-wheel, test, test-other-os, test-slow, test-core-only, cargo-test]
     steps:
       - uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: build-linux-wheel, test, test-other-os, test-slow, test-core-only
+          allowed-skips: build-linux-wheel, test, test-other-os, test-slow, test-core-only, cargo-test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,15 @@ include = [
 name = "_rhwp"
 crate-type = ["cdylib", "rlib"]
 
+# * extension-module 을 default features 에서 분리한다 — wheel 빌드 시에만 활성화
+#   cargo test 는 default 로 비활성 → libpython 링크 시도 회피 → Rust unit test 실행 가능
+#   ([PyO3 FAQ](https://pyo3.rs/main/faq#i-cant-run-cargo-test) 권장 패턴).
+#   maturin 은 [tool.maturin] features 에서 명시적으로 ["extension-module"] 활성화하므로 wheel 영향 0.
+[features]
+extension-module = ["pyo3/extension-module"]
+
 [dependencies]
-pyo3 = { version = "0.28", features = ["extension-module", "abi3-py310"] }
+pyo3 = { version = "0.28", features = ["abi3-py310"] }
 rhwp = { path = "external/rhwp" }
 
 [profile.release]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,9 @@ all = [
 python-source = "python"
 module-name = "rhwp._rhwp"
 bindings = "pyo3"
-features = ["pyo3/extension-module"]
+# ^ wheel 빌드 시 자기 crate 의 extension-module feature 를 켠다 (Cargo.toml [features] 정의).
+#   Cargo.toml 의 default features 에서는 extension-module 이 빠져 있어 cargo test 가 정상 작동.
+features = ["extension-module"]
 include = [
     { path = "python/rhwp/py.typed", format = "wheel" },
     { path = "python/rhwp/**/*.pyi", format = "wheel" },


### PR DESCRIPTION
## Summary

- PyO3 `extension-module` feature 를 default features 에서 분리해 `[features]` 섹션으로 이동
- `pyproject.toml [tool.maturin] features` 를 자기 crate 의 `extension-module` 가리키도록 변경 (wheel 빌드 동작 동일)
- 새 `cargo-test` job 추가 (Linux, Rust unit test 13개 실행)

## Why

기존 `Cargo.toml` 은 `pyo3 = { features = ["extension-module", ...] }` 로 default features 에 `extension-module` 이 들어가 있어 `cargo test` 가 libpython 링크 시도 → `_PyExc_SystemError` 등 심볼 부재로 실패. 이 때문에 `src/ir.rs` 의 `#[cfg(test)]` 모듈 (특히 `assert_position_invariant_panics_on_mismatch` 의 `#[should_panic]` 가드) 이 CI 에서 검증되지 않아, v0.3.1 spec AC-12 는 source-grep 우회 (`tests/test_v0_3_1_marker_char_offset.py::test_rust_uses_assert_eq_not_debug_assert`) 로만 보호되고 있었다.

[PyO3 FAQ "I can't run cargo test"](https://pyo3.rs/main/faq#i-cant-run-cargo-test) 권장 패턴 적용:

- default features 에서 \`extension-module\` 제거 → \`cargo test\` 정상 작동
- \`[features] extension-module = ["pyo3/extension-module"]\` 섹션 분리 → maturin 이 wheel 빌드 시 명시적 활성화 (영향 0)

## 검증

- \`cargo test --lib\` → 13 passed (\`utf16_to_cp\` / \`simple_eq_text_alt\` / \`field_type_to_str\` / \`caption_direction_to_str\` / \`assert_position_invariant_panics_on_mismatch\` (#[should_panic]) 포함)
- \`uv run maturin develop --release\` → wheel 빌드 정상 (\`cp310-abi3-macosx_11_0_arm64.whl\`)
- Python smoke pytest 37 passed → wheel 회귀 없음

## Reference 패턴

PyO3 + maturin 동일 스택 OSS 모두 default features 에서 \`extension-module\` 제거 패턴 사용:

- [pydantic-core Cargo.toml](https://github.com/pydantic/pydantic-core/blob/main/Cargo.toml) — \`pyo3 features = ["generate-import-lib", "num-bigint", "py-clone"]\` (extension-module 없음)
- [orjson Cargo.toml](https://github.com/ijl/orjson/blob/master/Cargo.toml) — \`pyo3-ffi default-features = false\`

## Related Issues

(없음 — build infra 정리)