### PR TITLE
ci: publish-schema 의 verify-sync 에 freetype / fontconfig 시스템 의존성 추가

### DIFF
--- a/.github/workflows/publish-schema.yml
+++ b/.github/workflows/publish-schema.yml
@@ -33,6 +33,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+      # ^ skia-safe (rhwp 의 native-skia feature) 가 Linux 에서 freetype / fontconfig 동적 링크.
+      #   ci.yml 의 build-linux-wheel / cargo-test 와 동일 패턴.
+      - name: Install skia-safe system dependencies (Linux)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libfreetype-dev libfontconfig1-dev
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: astral-sh/setup-uv@v8.1.0


### PR DESCRIPTION
## Summary

- publish-schema.yml 의 verify-sync 잡에 \`apt-get install libfreetype-dev libfontconfig1-dev\` 단계 추가

## Why

v0.6.0 머지 후 main 의 publish-schema 워크플로우가 처음 fail — verify-sync 가 \`maturin develop --release\` 하면서 native-skia 빌드, ci.yml 의 build-linux-wheel / cargo-test 와 동일한 시스템 의존성 누락. v0.6.0 PR 의 ci.yml 패치에서 본 워크플로우가 빠진 follow-up.

## Related Issues

—